### PR TITLE
Added "c-ares" packages to the container.

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -15,6 +15,8 @@ RUN set -ex && \
                                 tar \
                                 git \
                                 automake \
+                                c-ares \
+                                c-ares-dev \
                                 udns-dev && \
     cd /tmp && \
     git clone --depth=1 https://github.com/shadowsocks/simple-obfs.git . && \


### PR DESCRIPTION
Fixed a docker build fail issue: 
- Docker build failed with "configure: error: The c-ares library libraries not found" #1
